### PR TITLE
Add stress and pleasure

### DIFF
--- a/fpga/src/au_moody_mimosa.v
+++ b/fpga/src/au_moody_mimosa.v
@@ -24,7 +24,7 @@ module au_moody_mimosa (
     assign ui_in_model = { ui_in[7:1], clk_prescaled};
 
     // Instantiate the actual moody mimosa module
-    moody_mimosa mimosa (
+    tt_um_moody_mimosa mimosa (
         .ui_in(ui_in_model),              
         .uo_out(uo_out),         
         .uio_in(uio_in),

--- a/info.yaml
+++ b/info.yaml
@@ -16,6 +16,9 @@ project:
     - "edge_triggered_counter.v"
     - "saturating_counter.v"
     - "range_classifier.v"
+    - "energy_regulator.v"
+    - "stress_regulator.v"
+    - "pleasure_regulator.v"
 
 pinout:
   # Inputs

--- a/module_test/energy_regulator/Makefile
+++ b/module_test/energy_regulator/Makefile
@@ -1,0 +1,22 @@
+# Makefile
+
+# Defaults
+SIM ?= icarus
+TOPLEVEL_LANG ?= verilog
+SRC_DIR = $(PWD)/../../src
+PROJECT_SOURCES = energy_regulator.v
+
+# RTL simulation:
+SIM_BUILD		= sim_build/rtl
+VERILOG_SOURCES += $(addprefix $(SRC_DIR)/,$(PROJECT_SOURCES))
+COMPILE_ARGS    += -I$(SRC_DIR)
+
+# Include the testbench sources:
+VERILOG_SOURCES += $(PWD)/tb_energy_regulator.v
+TOPLEVEL = tb_energy_regulator
+
+# MODULE is the basename of the Python test file
+MODULE = test_energy_regulator
+
+# Include cocotb's make rules to take care of the simulator setup
+include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/module_test/energy_regulator/tb_energy_regulator.v
+++ b/module_test/energy_regulator/tb_energy_regulator.v
@@ -1,0 +1,27 @@
+`default_nettype none
+`timescale 1ns / 1ps
+
+module tb_energy_regulator ();
+
+  // Dump the signals to a VCD file
+  initial begin
+    $dumpfile("tb_energy_regulator.vcd");
+    $dumpvars(0, tb_energy_regulator);
+    #1;
+  end
+
+  // Wire up the inputs and outputs:
+  reg sleep_controller_inc;
+  reg sleep_controller_dec;
+  reg energy_inc;
+  reg energy_dec;
+
+  // Instantiate energy_regulator classifier module 
+  energy_regulator dut (
+      .sleep_controller_inc (sleep_controller_inc),   
+      .sleep_controller_dec (sleep_controller_dec),
+      .energy_inc (energy_inc),
+      .energy_dec (energy_dec)
+  );
+
+endmodule

--- a/module_test/energy_regulator/test_energy_regulator.py
+++ b/module_test/energy_regulator/test_energy_regulator.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: © 2024 Tiny Tapeout
+# SPDX-License-Identifier: Apache-2.0
+
+import cocotb
+from cocotb.triggers import Timer
+from itertools import product
+
+async def init(dut):
+    dut._log.info("Start")
+    dut.sleep_controller_inc.value = 0
+    dut.sleep_controller_dec.value = 0
+    await Timer(1, units='ns')
+
+@cocotb.test()
+async def test_energy_regulator(dut):
+    """
+    Check all combinations
+            """
+    await init(dut)
+
+    for inc, dec in product([0, 1], repeat=2):
+        dut.sleep_controller_inc.value = inc
+        dut.sleep_controller_dec.value = dec
+        await Timer(1, units='ns')
+        assert dut.energy_inc.value == inc
+        assert dut.energy_dec.value == dec

--- a/module_test/pleasure_regulator/Makefile
+++ b/module_test/pleasure_regulator/Makefile
@@ -1,0 +1,22 @@
+# Makefile
+
+# Defaults
+SIM ?= icarus
+TOPLEVEL_LANG ?= verilog
+SRC_DIR = $(PWD)/../../src
+PROJECT_SOURCES = pleasure_regulator.v
+
+# RTL simulation:
+SIM_BUILD		= sim_build/rtl
+VERILOG_SOURCES += $(addprefix $(SRC_DIR)/,$(PROJECT_SOURCES))
+COMPILE_ARGS    += -I$(SRC_DIR)
+
+# Include the testbench sources:
+VERILOG_SOURCES += $(PWD)/tb_pleasure_regulator.v
+TOPLEVEL = tb_pleasure_regulator
+
+# MODULE is the basename of the Python test file
+MODULE = test_pleasure_regulator
+
+# Include cocotb's make rules to take care of the simulator setup
+include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/module_test/pleasure_regulator/tb_pleasure_regulator.v
+++ b/module_test/pleasure_regulator/tb_pleasure_regulator.v
@@ -1,0 +1,29 @@
+`default_nettype none
+`timescale 1ns / 1ps
+
+module tb_pleasure_regulator ();
+
+  // Dump the signals to a VCD file
+  initial begin
+    $dumpfile("tb_pleasure_regulator.vcd");
+    $dumpvars(0, tb_pleasure_regulator);
+    #1;
+  end
+
+  // Wire up the inputs and outputs:
+  reg sleep_controller_inc;
+  reg sleep_controller_dec;
+  reg [6:0] stimuli;
+  wire pleasure_inc;
+  wire pleasure_dec;
+
+  // Instantiate stess_regulator classifier module 
+  pleasure_regulator dut (
+      .sleep_controller_inc (sleep_controller_inc),   
+      .sleep_controller_dec (sleep_controller_dec),
+      .stimuli (stimuli),
+      .pleasure_inc (pleasure_inc),
+      .pleasure_dec (pleasure_dec)
+  );
+
+endmodule

--- a/module_test/pleasure_regulator/test_pleasure_regulator.py
+++ b/module_test/pleasure_regulator/test_pleasure_regulator.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: © 2024 Tiny Tapeout
+# SPDX-License-Identifier: Apache-2.0
+
+import cocotb
+from cocotb.triggers import Timer
+from itertools import product
+
+async def init(dut):
+    dut._log.info("Start")
+    dut.sleep_controller_inc.value = 0
+    dut.sleep_controller_dec.value = 0
+    dut.stimuli.value = 0
+    await Timer(1, units='ns')
+
+@cocotb.test()
+async def test_pleasure_regulator_no_stimuli(dut):
+    """
+    Check all combinations without external stimuli
+    """
+    await init(dut)
+
+    dut.stimuli.value = 0
+
+    for inc, dec in product([0, 1], repeat=2):
+        dut.sleep_controller_inc.value = inc
+        dut.sleep_controller_dec.value = dec
+        await Timer(1, units='ns')
+        assert dut.pleasure_inc.value == inc
+        assert dut.pleasure_dec.value == dec
+
+@cocotb.test()
+async def test_pleasure_regulator_with_stimuli(dut):
+    """
+    Check all combinations with external stimuli
+    """
+    await init(dut)
+
+    dut.stimuli.value = 2
+
+    for inc, dec in product([0, 1], repeat=2):
+        dut.sleep_controller_inc.value = inc
+        dut.sleep_controller_dec.value = dec
+        await Timer(1, units='ns')
+
+        # Independent of sleep controller
+        assert dut.pleasure_inc.value == 1
+        assert dut.pleasure_dec.value == 0
+
+    

--- a/module_test/saturating_counter/test_saturating_counter.py
+++ b/module_test/saturating_counter/test_saturating_counter.py
@@ -31,10 +31,10 @@ async def test_sat_counter_init(dut):
     
     await init(dut)
 
-    # Check that initial value is 2^N/2
+    # Check that initial value is 1 or value specified
     assert dut.value_2bit.value == 2
-    assert dut.value_8bit.value == 128
-    assert dut.value_16bit.value == 32768
+    assert dut.value_8bit.value == 2
+    assert dut.value_16bit.value == 2
 
 @cocotb.test()
 async def test_sat_counter_reset(dut):
@@ -49,16 +49,16 @@ async def test_sat_counter_reset(dut):
 
     # Check that value is not 2^N/2
     assert dut.value_2bit.value != 2
-    assert dut.value_8bit.value != 128
-    assert dut.value_16bit.value != 32768
+    assert dut.value_8bit.value != 2
+    assert dut.value_16bit.value != 2
 
     dut.rst_n.value = 0
     await ClockCycles(dut.clk, 2)
 
     # Check that value is 2^N/2
     assert dut.value_2bit.value == 2
-    assert dut.value_8bit.value == 128
-    assert dut.value_16bit.value == 32768
+    assert dut.value_8bit.value == 2
+    assert dut.value_16bit.value == 2
 
 @cocotb.test()
 async def test_sat_counter_2bit(dut):

--- a/module_test/stress_regulator/Makefile
+++ b/module_test/stress_regulator/Makefile
@@ -1,0 +1,22 @@
+# Makefile
+
+# Defaults
+SIM ?= icarus
+TOPLEVEL_LANG ?= verilog
+SRC_DIR = $(PWD)/../../src
+PROJECT_SOURCES = stress_regulator.v
+
+# RTL simulation:
+SIM_BUILD		= sim_build/rtl
+VERILOG_SOURCES += $(addprefix $(SRC_DIR)/,$(PROJECT_SOURCES))
+COMPILE_ARGS    += -I$(SRC_DIR)
+
+# Include the testbench sources:
+VERILOG_SOURCES += $(PWD)/tb_stress_regulator.v
+TOPLEVEL = tb_stress_regulator
+
+# MODULE is the basename of the Python test file
+MODULE = test_stress_regulator
+
+# Include cocotb's make rules to take care of the simulator setup
+include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/module_test/stress_regulator/tb_stress_regulator.v
+++ b/module_test/stress_regulator/tb_stress_regulator.v
@@ -1,0 +1,29 @@
+`default_nettype none
+`timescale 1ns / 1ps
+
+module tb_stress_regulator ();
+
+  // Dump the signals to a VCD file
+  initial begin
+    $dumpfile("tb_stress_regulator.vcd");
+    $dumpvars(0, tb_stress_regulator);
+    #1;
+  end
+
+  // Wire up the inputs and outputs:
+  reg sleep_controller_inc;
+  reg sleep_controller_dec;
+  reg [6:0] stimuli;
+  wire stress_inc;
+  wire stress_dec;
+
+  // Instantiate stess_regulator classifier module 
+  stress_regulator dut (
+      .sleep_controller_inc (sleep_controller_inc),   
+      .sleep_controller_dec (sleep_controller_dec),
+      .stimuli (stimuli),
+      .stress_inc (stress_inc),
+      .stress_dec (stress_dec)
+  );
+
+endmodule

--- a/module_test/stress_regulator/test_stress_regulator.py
+++ b/module_test/stress_regulator/test_stress_regulator.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: © 2024 Tiny Tapeout
+# SPDX-License-Identifier: Apache-2.0
+
+import cocotb
+from cocotb.triggers import Timer
+from itertools import product
+
+async def init(dut):
+    dut._log.info("Start")
+    dut.sleep_controller_inc.value = 0
+    dut.sleep_controller_dec.value = 0
+    dut.stimuli.value = 0
+    await Timer(1, units='ns')
+
+@cocotb.test()
+async def test_stress_regulator_no_stimuli(dut):
+    """
+    Check all combinations without external stimuli
+    """
+    await init(dut)
+
+    dut.stimuli.value = 0
+
+    for inc, dec in product([0, 1], repeat=2):
+        dut.sleep_controller_inc.value = inc
+        dut.sleep_controller_dec.value = dec
+        await Timer(1, units='ns')
+        assert dut.stress_inc.value == inc
+        assert dut.stress_dec.value == dec
+
+@cocotb.test()
+async def test_stress_regulator_with_stimuli(dut):
+    """
+    Check all combinations with external stimuli
+    """
+    await init(dut)
+
+    dut.stimuli.value = 1
+
+    for inc, dec in product([0, 1], repeat=2):
+        dut.sleep_controller_inc.value = inc
+        dut.sleep_controller_dec.value = dec
+        await Timer(1, units='ns')
+
+        # Independent of sleep controller
+        assert dut.stress_inc.value == 1
+        assert dut.stress_dec.value == 0
+
+    

--- a/src/energy_regulator.v
+++ b/src/energy_regulator.v
@@ -1,0 +1,14 @@
+`default_nettype none
+
+module energy_regulator (
+    input wire sleep_controller_inc,
+    input wire sleep_controller_dec,
+    output wire energy_inc, 
+    output wire energy_dec
+);
+
+    // Currently no complex decision
+    assign energy_inc = sleep_controller_inc;
+    assign energy_dec = sleep_controller_dec;
+
+endmodule

--- a/src/moody_mimosa.v
+++ b/src/moody_mimosa.v
@@ -16,14 +16,23 @@ module tt_um_moody_mimosa (
 
     wire [6:0] energy;
     wire [1:0] energy_indicator;
+    wire energy_inc;
+    wire energy_dec;
+
+    wire [6:0] stress;
     wire [1:0] stress_indicator;
+    wire stress_inc;
+    wire stress_dec;
+
+    wire [6:0] pleasure;
+    wire [1:0] pleasure_indicator; 
+    wire pleasure_inc;
+    wire pleasure_dec;
+
     wire setval;
     wire asleep;
     wire fell_asleep;
-    wire en_inc;
-    wire en_dec;
 
-    assign stress_indicator = 0;
     assign setval  = 0;
 
     sleep_controller sleep_ctrl (
@@ -33,15 +42,15 @@ module tt_um_moody_mimosa (
         .stress_indicator(stress_indicator), 
         .asleep(asleep), 
         .fell_asleep(fell_asleep),
-        .en_inc(en_inc),
-        .en_dec(en_dec)
+        .en_inc(energy_inc),
+        .en_dec(energy_dec)
     );
 
-    saturating_counter #(.N(7), .SET_VAL(64)) energy_cnt (
+    saturating_counter #(.N(7), .SET_VAL(64)) energy_counter (
         .clk(ui_in[0]),
         .rst_n(rst_n), 
-        .inc(en_inc),
-        .dec(en_dec),
+        .inc(energy_inc),
+        .dec(energy_dec),
         .setval(setval), 
         .value(energy)
     );
@@ -50,10 +59,38 @@ module tt_um_moody_mimosa (
         .number(energy), 
         .out_bits(energy_indicator)
     );
+
+    saturating_counter #(.N(7), .SET_VAL(64)) stress_counter (
+        .clk(ui_in[0]),
+        .rst_n(rst_n), 
+        .inc(stress_inc),
+        .dec(stress_dec),
+        .setval(setval), 
+        .value(stress)
+    );
+
+    range_classifier #(.N(7)) stress_classifier (
+        .number(stress), 
+        .out_bits(stress_indicator)
+    );
+
+    saturating_counter #(.N(7), .SET_VAL(64)) pleasure_counter (
+        .clk(ui_in[0]),
+        .rst_n(rst_n), 
+        .inc(pleasure_inc),
+        .dec(pleasure_dec),
+        .setval(setval), 
+        .value(pleasure)
+    );
+
+    range_classifier #(.N(7)) pleasure_classifier (
+        .number(pleasure), 
+        .out_bits(pleasure_classifier)
+    );
     
     // Output assignments
     assign uo_out = {asleep, energy};
-    assign uio_out = {2'b00, asleep, fell_asleep, en_inc, en_dec, energy_indicator};                // Unused outputs set to 0
+    assign uio_out = 0;                // Unused outputs set to 0
     assign uio_oe  = 0;                // Unused, all set to input (inactive)
 
 endmodule

--- a/src/pleasure_regulator.v
+++ b/src/pleasure_regulator.v
@@ -1,0 +1,15 @@
+`default_nettype none
+
+module pleasure_regulator (
+    input wire sleep_controller_inc,
+    input wire sleep_controller_dec,
+    input wire [6:0] stimuli,
+    output wire pleasure_inc, 
+    output wire pleasure_dec
+);
+
+    // Currently no complex decision
+    assign pleasure_inc = stimuli[1] ? 1'b1 : sleep_controller_inc;
+    assign pleasure_dec = stimuli[1] ? 1'b0 : sleep_controller_dec;
+
+endmodule

--- a/src/pleasure_regulator.v
+++ b/src/pleasure_regulator.v
@@ -10,6 +10,6 @@ module pleasure_regulator (
 
     // Currently no complex decision
     assign pleasure_inc = stimuli[1] ? 1'b1 : sleep_controller_inc;
-    assign pleasure_dec = stimuli[1] ? 1'b0 : sleep_controller_dec;
+    assign pleasure_dec = stimuli[0] ? 1'b1 : sleep_controller_dec;
 
 endmodule

--- a/src/saturating_counter.v
+++ b/src/saturating_counter.v
@@ -1,6 +1,6 @@
 `default_nettype none
 
-module saturating_counter #(parameter N = 8, parameter SET_VAL = 0) (
+module saturating_counter #(parameter N = 8, parameter SET_VAL = 0, parameter DEFAULT_VAL = 2) (
     input wire clk,              // Clock input
     input wire rst_n,            // Reset input
     input wire inc,              // Increment signal
@@ -11,7 +11,7 @@ module saturating_counter #(parameter N = 8, parameter SET_VAL = 0) (
 
     always @(posedge clk) begin
         if (!rst_n) begin
-            value <= {1'b1, {N-1{1'b0}}};
+            value <= DEFAULT_VAL;
         end else if (setval) begin
             value <= SET_VAL;
         end else begin

--- a/src/sleep_controller.v
+++ b/src/sleep_controller.v
@@ -6,7 +6,9 @@ module sleep_controller (
     output reg asleep,
     output reg fell_asleep,
     output reg en_inc,
-    output reg en_dec
+    output reg en_dec, 
+    output reg st_dec,
+    output reg pl_inc
 );
 
     // State encoding
@@ -20,6 +22,8 @@ module sleep_controller (
             fell_asleep <= 1'b0;
             en_inc <= 1'b0;
             en_dec <= 1'b0;
+            st_dec <= 1'b0;
+            pl_inc <= 1'b0;
         end else begin
             fell_asleep <= 1'b0;
 
@@ -28,6 +32,8 @@ module sleep_controller (
                     asleep <= 1'b0;
                     en_inc <= 1'b0;
                     en_dec <= 1'b1;
+                    st_dec <= 1'b0;
+                    pl_inc <= 1'b0;
 
                     if (energy_indicator[1] == 0 && !stress_indicator[1]) begin
                         state <= ASLEEP;
@@ -39,6 +45,8 @@ module sleep_controller (
                     asleep <= 1'b1;
                     en_inc <= 1'b1;
                     en_dec <= 1'b0;
+                    st_dec <= 1'b1; // Stress reduces while asleep
+                    pl_inc <= 1'b1; // Mood improves while asleep
 
                     if (energy_indicator == 2'b11 || stress_indicator[1] == 1) begin
                         state <= AWAKE;

--- a/src/stress_regulator.v
+++ b/src/stress_regulator.v
@@ -10,6 +10,6 @@ module stress_regulator (
 
     // Currently no complex decision
     assign stress_inc = stimuli[0] ? 1'b1 : sleep_controller_inc;
-    assign stress_dec = stimuli[0] ? 1'b0 : sleep_controller_dec;
+    assign stress_dec = stimuli[1] ? 1'b1 : sleep_controller_dec;
 
 endmodule

--- a/src/stress_regulator.v
+++ b/src/stress_regulator.v
@@ -1,0 +1,15 @@
+`default_nettype none
+
+module stress_regulator (
+    input wire sleep_controller_inc,
+    input wire sleep_controller_dec,
+    input wire [6:0] stimuli,
+    output wire stress_inc, 
+    output wire stress_dec
+);
+
+    // Currently no complex decision
+    assign stress_inc = stimuli[0] ? 1'b1 : sleep_controller_inc;
+    assign stress_dec = stimuli[0] ? 1'b0 : sleep_controller_dec;
+
+endmodule

--- a/test/Makefile
+++ b/test/Makefile
@@ -11,6 +11,9 @@ PROJECT_SOURCES += edge_triggered_counter.v
 PROJECT_SOURCES += range_classifier.v
 PROJECT_SOURCES += saturating_counter.v
 PROJECT_SOURCES += sleep_controller.v
+PROJECT_SOURCES += energy_regulator.v
+PROJECT_SOURCES += stress_regulator.v
+PROJECT_SOURCES += pleasure_regulator.v
 
 
 ifneq ($(GATES),yes)


### PR DESCRIPTION
- Added stress and pleasure as resource.
- Added minimal energy, stress and pleasure regulator deciding depending on various inputs, whether the resource should be increased, decreased or left untouched. The regulators will likely be extended once it is defined, what kind of input the moody mimosa gets from the outside world.
- Routed inputs 1 and 2 to influence stress and pleasure. Input 1 (lower button on Alchitry Io board) increases stress and decreases pleausre. Input 2 (middle button on Alchitry Io board) increases pleasure and decreases stress. 
- Updated application and fixed tests